### PR TITLE
Upgraded to separate PropTypes package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # react-ellipsis-text [![Build Status](https://travis-ci.org/georgeOsdDev/react-ellipsis-text.svg?branch=master)](https://travis-ci.org/georgeOsdDev/react-ellipsis-text) [![npm version](https://badge.fury.io/js/react-ellipsis-text.svg)](http://badge.fury.io/js/react-ellipsis-text)
+
 [![NPM](https://nodei.co/npm/react-ellipsis-text.png)](https://nodei.co/npm/react-ellipsis-text/)
 React text ellipsify component
 
@@ -20,43 +21,41 @@ npm install --save react-ellipsis-text
 
 ```javascript
 EllipsisText.propTypes = {
-  text: React.PropTypes.string.isRequired,
-  length: React.PropTypes.number.isRequired,
-  tail: React.PropTypes.string,
-  tailClassName: React.PropTypes.string,
-  tooltip: React.PropTypes.shape({
-    copyOnClick: React.PropTypes.bool,
-    onAppear: React.PropTypes.func,
-    onDisapepear: React.PropTypes.func
+  text: PropTypes.string.isRequired,
+  length: PropTypes.number.isRequired,
+  tail: PropTypes.string,
+  tailClassName: PropTypes.string,
+  tooltip: PropTypes.shape({
+    copyOnClick: PropTypes.bool,
+    onAppear: PropTypes.func,
+    onDisapepear: PropTypes.func
   })
 };
 ```
 
-  * `text`: Text to display
+- `text`: Text to display
 
-  * `length`: Max length of text
+- `length`: Max length of text
 
-  * `tail`: Trailing string (Default '...')
+- `tail`: Trailing string (Default '...')
 
-  * `tailClassName`: Trailing string element's class name
+- `tailClassName`: Trailing string element's class name
 
-  * `tooltip`: Tooltip will be display when supplied
+- `tooltip`: Tooltip will be display when supplied
 
-  * `tooltip.clipboard`: Original text will be copied into clipboard when tooltip is clicked.
+- `tooltip.clipboard`: Original text will be copied into clipboard when tooltip is clicked.
 
-  * `tooltip.onAppear`: Called when tooltip is shown.
+- `tooltip.onAppear`: Called when tooltip is shown.
 
-  * `tooltip.onDisapepear`: Called when tooltip is hidden.
-
+- `tooltip.onDisapepear`: Called when tooltip is hidden.
 
 ## Usage example
 
 ```javascript
+"use strict";
 
-'use strict';
-
-import React from 'react';
-import EllipsisText  from 'react-ellipsis-text';
+import React from "react";
+import EllipsisText from "react-ellipsis-text";
 
 //allow react dev tools work
 window.React = React;
@@ -69,24 +68,22 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <EllipsisText text={'1234567890'} length={'5'} />
+        <EllipsisText text={"1234567890"} length={"5"} />
       </div>
-    )
+    );
   }
-};
+}
 
-React.render(<App/>, document.getElementById('out'));
+React.render(<App />, document.getElementById("out"));
 
 // It will be
 // <div>
 //   <span><span>12</sapn><span class='more'>...</span></span>
 //  </div>
 //
-
 ```
 
-
-See  [example](https://github.com/georgeOsdDev/react-ellipsis-text/tree/develop/example)
+See [example](https://github.com/georgeOsdDev/react-ellipsis-text/tree/develop/example)
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
+    "prop-types": "^15.6.2",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"
   },

--- a/src/components/EllipsisText.js
+++ b/src/components/EllipsisText.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 const styles = {
   allText: {
     MozUserSelect: 'text',
@@ -51,10 +53,10 @@ class EllipsisText extends React.Component {
 }
 
 EllipsisText.propTypes = {
-  text: React.PropTypes.string.isRequired,
-  length: React.PropTypes.number.isRequired,
-  tail: React.PropTypes.string,
-  tailClassName: React.PropTypes.string,
+  text: PropTypes.string.isRequired,
+  length: PropTypes.number.isRequired,
+  tail: PropTypes.string,
+  tailClassName: PropTypes.string,
 };
 
 EllipsisText.defaultProps = {


### PR DESCRIPTION
To solve the following warning, upgraded the PropTypes.

`Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs`